### PR TITLE
configs: HiFive Premier P550 - initialize sata

### DIFF
--- a/configs/hifive_premier_p550_defconfig
+++ b/configs/hifive_premier_p550_defconfig
@@ -109,4 +109,4 @@ CONFIG_VIDEO_ANSI=y
 CONFIG_USB_KEYBOARD=y
 CONFIG_USE_PREBOOT=y
 CONFIG_SYS_64BIT_LBA=y
-CONFIG_PREBOOT="setenv fdt_addr ${fdtcontroladdr};fdt addr ${fdtcontroladdr};usb start"
+CONFIG_PREBOOT="setenv fdt_addr ${fdtcontroladdr};fdt addr ${fdtcontroladdr};usb start;sata init"


### PR DESCRIPTION
The SATA drive can only be used after initialization.
