### PR TITLE
riscv/hifive_premier_p550: lower $kernel_comp_addr_r

### DIFF
--- a/include/configs/hifive_premier_p550.h
+++ b/include/configs/hifive_premier_p550.h
@@ -31,7 +31,7 @@
     "stdin=serial,usbkbd\0" \
     "stderr=serial,vidconsole\0" \
     "stdout=serial,vidconsole\0" \
-    "kernel_comp_addr_r=0x180000000\0" \
+    "kernel_comp_addr_r=0xa0000000\0" \
     "kernel_comp_size=0x4000000\0"
 
 #define MMC_ENV \


### PR DESCRIPTION
$kernel_comp_addr_r above 4 GiB leads to an error

    kernel_comp_addr_r is outside of DRAM range!

Use 0xa0000000 which leaves enough space for loading the initramfs.