### PR TITLE
riscv/hifive_premier_p550: define fdtfile

### DIFF
--- a/include/configs/hifive_premier_p550.h
+++ b/include/configs/hifive_premier_p550.h
@@ -30,6 +30,7 @@
     "initrd_high=0xffffffffffffffff\0" \
     "kernel_addr_r=0x84000000\0" \
     "fdt_addr_r=0x88000000\0" \
+    "fdtfile=eswin/hifive-premier-p550.dtb\0" \
     "scriptaddr=0x88100000\0" \
     "pxefile_addr_r=0x88200000\0" \
     "ramdisk_addr_r=0x88300000\0" \


### PR DESCRIPTION
The variable $fdtfile is needed in distro-booting to find the device-tree.