### PR TITLE
Fix build errors

### DIFF
--- a/arch/riscv/cpu/eic7700/dram.c
+++ b/arch/riscv/cpu/eic7700/dram.c
@@ -5,6 +5,7 @@
  *  Author: Xiang Xu <xuxiang@eswincomputing.com>
  */
 
+#include <efi_loader.h>
 #include <fdtdec.h>
 #include <init.h>
 #include <mapmem.h>

--- a/arch/riscv/include/asm/cache.h
+++ b/arch/riscv/include/asm/cache.h
@@ -11,6 +11,7 @@
 void cache_flush(void);
 void flush_dcache_range(unsigned long start, unsigned long end);
 void invalidate_dcache_range(unsigned long start, unsigned long end);
+void flush_cache(unsigned long addr, unsigned long size);
 /*
  * The current upper bound for RISCV L1 data cache line sizes is 32 bytes.
  * We use that value for aligning DMA buffers unless the board config has

--- a/arch/riscv/lib/cache.c
+++ b/arch/riscv/lib/cache.c
@@ -4,6 +4,7 @@
  * Rick Chen, Andes Technology Corporation <rick@andestech.com>
  */
 
+#include <asm/cache.h>
 #include <cpu_func.h>
 
 void invalidate_icache_all(void)

--- a/arch/riscv/lib/reset.c
+++ b/arch/riscv/lib/reset.c
@@ -7,7 +7,7 @@
 #include <hang.h>
 #include <asm/io.h>
 
-#define RESET_REG	(0x51828300UL)
+#define RESET_REG	((void *)0x51828300UL)
 int do_reset(struct cmd_tbl *cmdtp, int flag, int argc, char *const argv[])
 {
 	printf("resetting ...\n");

--- a/board/eswin/hifive_premier_p550/hifive_premier_p550.c
+++ b/board/eswin/hifive_premier_p550/hifive_premier_p550.c
@@ -155,7 +155,7 @@ void irq_mux_route(void)
 	*/
 
 	val = 0;
-	writel(val,0x51810000+0x3c0);
+	writel(val,(void *)(0x51810000+0x3c0));
 }
 
 int board_init(void)

--- a/cmd/eswin/es_bootloader.c
+++ b/cmd/eswin/es_bootloader.c
@@ -37,6 +37,7 @@
 #include <spi.h>
 #include <spi_flash.h>
 #include <fs.h>
+#include <dm/device-internal.h>
 #include <eswin/esw_mkfs.h>
 
 // #define DEBUG

--- a/cmd/eswin/es_bootloader.c
+++ b/cmd/eswin/es_bootloader.c
@@ -306,7 +306,7 @@ static int norflash_write_bootchain(uint64_t src_addr, uint64_t offset, uint64_t
 		}
 		total_size -= BOOTCHAIN_PACKAGE_SIZE;
 		ret = spi_flash_write(flash, offset + i * BOOTCHAIN_PACKAGE_SIZE, write_size,
-						      src_addr + i * BOOTCHAIN_PACKAGE_SIZE);
+				      (void *)(src_addr + i * BOOTCHAIN_PACKAGE_SIZE));
 		currentIndex = (uint64_t)i * 100 / package_blk;
 		printf("Write progress: %3lld%%:", currentIndex);
 		for(int col = 0; col < currentIndex/2; col++) {

--- a/common/eswin/eswupdate/display_update.c
+++ b/common/eswin/eswupdate/display_update.c
@@ -23,9 +23,9 @@
 #include <fat.h>
 #include <image.h>
 #include <mmc.h>
+#include <update_init.h>
 #include "../../../drivers/mini_graphic_library/mglib_driver.h"
 #include "../../../drivers/mini_graphic_library/mglib_api.h"
-#include "update_init.h"
 
 #ifdef CONFIG_DRM_ESWIN_DW_HDMI
 #define X_AXIS       400

--- a/common/eswin/eswupdate/system_update.c
+++ b/common/eswin/eswupdate/system_update.c
@@ -28,8 +28,11 @@
 #include <system_update.h>
 #include <boot_ab.h>
 #include <display_update.h>
+#include <asm/cache.h>
+#include <asm/mbox.h>
 #include <eswin/eswin-service.h>
 #include <eswin/eswin-uMsg.h>
+#include <eswin/esw_mkfs.h>
 #include <eswin/ipc.h>
 #include <dm/uclass.h>
 
@@ -160,7 +163,7 @@ static int check_signature_value(int mode, int index)
     ret = eswin_umbox_service_send(dev, (u8*)&srvcReq);
     if (0 != ret) goto Failed;
 
-    ret = eswin_umbox_service_recv(dev, (u8*)&recvMsg);
+    ret = eswin_umbox_service_recv(dev, (u32*)&recvMsg);
     if (0 != ret) goto Failed;
 
     debug("\r\n");
@@ -277,7 +280,7 @@ static int check_header_valid(uint64_t size, uint8_t sign_type, uint8_t key_inde
         if (0 != ret){
             printf("eswin_umbox_test_send failed\n");
         }
-        ret = eswin_umbox_service_recv(dev, (u8*)&recvMsg);
+        ret = eswin_umbox_service_recv(dev, (u32*)&recvMsg);
         if (0 != ret){
             printf("eswin_umbox_test_recv failed\n");
         }

--- a/common/eswin/eswupdate/system_update.c
+++ b/common/eswin/eswupdate/system_update.c
@@ -132,9 +132,9 @@ static int check_signature_value(int mode, int index)
     if(sign_type == SIGN_TYPE_PLAINTEXT)
         return 0;
     size = feht->size;
-    signAddr = LOAD_ADDR_SIG_IMA;
-    imageAddr = LOAD_ADDR_SIG_IMA + SIGN_SIZE;
-    destAddr = TEST_DSET;
+    signAddr = (void *)LOAD_ADDR_SIG_IMA;
+    imageAddr = (void *)(LOAD_ADDR_SIG_IMA + SIGN_SIZE);
+    destAddr = (void *)TEST_DSET;
 
     srvcReq.SrvcType = SRVC_TYPE_SIGN_CHECK;                             //service ID
     srvcReq.data.SigChkReq.flag.bAlgorithm = (u8)sign_type;
@@ -225,7 +225,7 @@ static unsigned long long int ntohl64(unsigned long long int netlong)
  * else return -1.
  *
  */
-u64 sign_destaddr = 0;
+static void *sign_destaddr = NULL;
 static int check_header_valid(uint64_t size, uint8_t sign_type, uint8_t key_index, uint32_t version)
 {
     int srvc_type = 3;    /* SRVC_TYPE_RSA_CRYPT_DECRYPT 0x03 */
@@ -240,10 +240,10 @@ static int check_header_valid(uint64_t size, uint8_t sign_type, uint8_t key_inde
     RECV_MSG_EXT_T recvMsg;
 
     /* prepare service request data */
-    signAddr = LOAD_ADDR_SIG_IMA;
-    imageAddr = LOAD_ADDR_SIG_IMA + SIGN_SIZE;
-    destAddr = TEST_DSET;
-    sign_destaddr = TEST_DSET;
+    signAddr = (void *)LOAD_ADDR_SIG_IMA;
+    imageAddr = (void *)(LOAD_ADDR_SIG_IMA + SIGN_SIZE);
+    destAddr = (void *)TEST_DSET;
+    sign_destaddr = (void *)TEST_DSET;
     if(sign_type == SIGN_TYPE_PLAINTEXT)
     {
         sign_destaddr = signAddr;

--- a/drivers/ata/dwc_ahsata_eswin.c
+++ b/drivers/ata/dwc_ahsata_eswin.c
@@ -33,6 +33,7 @@
 #include <malloc.h>
 #include <memalign.h>
 #include <part.h>
+#include <reset.h>
 #include <sata.h>
 #include <asm/cache.h>
 #include <asm/io.h>
@@ -948,7 +949,7 @@ static int eswin_sata_clk_enable(struct udevice *dev)
 static int eswin_sata_reset(struct udevice *dev)
 {
     int ret = 0;
-	struct reset_control *sata_arstn;
+	struct reset_ctl *sata_arstn;
 	sata_arstn = devm_reset_control_get(dev, "hsp_sata_arstn");
 	if (IS_ERR_OR_NULL(sata_arstn)) {
         dev_err(dev, "Failed to asic0_rst handle\n");

--- a/drivers/spi/es_spi.c
+++ b/drivers/spi/es_spi.c
@@ -307,12 +307,12 @@ static int es_spi_of_to_plat(struct udevice *bus)
 	dev_info(bus, "max-frequency=%d\n", plat->frequency);
 	plat->sys_regs = (void *)(uintptr_t)dev_read_u32_default(bus, "es,sysscr_reg",
 					       0x51828000);
-	plat->write_status_reg_time = (void *)(uintptr_t)dev_read_u32_default(bus, "write-status-reg-time", 15);
-	plat->page_program_time = (void *)(uintptr_t)dev_read_u32_default(bus, "page-program-time", 3);
-	plat->sector_erase_time = (void *)(uintptr_t)dev_read_u32_default(bus, "sector-erase-time", 400);
-	plat->small_block_erase_time = (void *)(uintptr_t)dev_read_u32_default(bus, "small-block-erase-time", 1600);
-	plat->large_block_erase_time = (void *)(uintptr_t)dev_read_u32_default(bus, "large-block-erase-time", 2000);
-	plat->chip_erase_time = (void *)(uintptr_t)dev_read_u32_default(bus, "chip-erase-time", 200);
+	plat->write_status_reg_time = (uintptr_t)dev_read_u32_default(bus, "write-status-reg-time", 15);
+	plat->page_program_time = (uintptr_t)dev_read_u32_default(bus, "page-program-time", 3);
+	plat->sector_erase_time = (uintptr_t)dev_read_u32_default(bus, "sector-erase-time", 400);
+	plat->small_block_erase_time = (uintptr_t)dev_read_u32_default(bus, "small-block-erase-time", 1600);
+	plat->large_block_erase_time = (uintptr_t)dev_read_u32_default(bus, "large-block-erase-time", 2000);
+	plat->chip_erase_time = (uintptr_t)dev_read_u32_default(bus, "chip-erase-time", 200);
 
 	dev_dbg(bus, "write_status_reg_time %d, page_program_time %d "
 			"sector_erase_time %d, small_block_erase_time %d "

--- a/env/sf.c
+++ b/env/sf.c
@@ -17,6 +17,7 @@
 #include <spi_flash.h>
 #include <search.h>
 #include <errno.h>
+#include <update_init.h>
 #include <uuid.h>
 #include <asm/cache.h>
 #include <asm/global_data.h>

--- a/include/update_init.h
+++ b/include/update_init.h
@@ -132,4 +132,6 @@ void usb_update_exit(void);
 
 int draw_background(void);
 
+void es_bootspi_wp_cfg(int enable);
+
 #endif

--- a/include/update_init.h
+++ b/include/update_init.h
@@ -130,4 +130,6 @@ void mmc_update_exit(void);
 int usb_update_init(void);
 void usb_update_exit(void);
 
+int draw_background(void);
+
 #endif


### PR DESCRIPTION
u-boot-2024.01-EIC7X as of commit d96a12a04f1fd does not build on Ubuntu 24.10.

These patches are enough to allow building again. But a lot of warnings remain.