### PR TITLE
Fix build warnings

### DIFF
--- a/common/eswin/eswupdate/update_init.c
+++ b/common/eswin/eswupdate/update_init.c
@@ -42,10 +42,10 @@ static int get_misc_command(struct blk_desc *dev_desc, struct disk_partition *pa
     }
     printf("bootloader_message info\n \
             magic : 0x%08x\t command : %s\t crc32_bc : 0x%08x \n\
-            kernel : boot%c \t rootfs : rootfs%c \n\
+            kernel : boot%s \t rootfs : rootfs%s \n\
             ", abc->magic, abc->command, abc->crc32_bc,\
-            ( abc->curr_bank == 0 )?'a':  ( abc->curr_bank == 1)?'b':' err', \
-            ( abc->rtfs_bank == 0 )?'a':  ( abc->rtfs_bank == 1)?'b':' err');
+            ( abc->curr_bank == 0 )?"a":  ( abc->curr_bank == 1)?"b":" err", \
+            ( abc->rtfs_bank == 0 )?"a":  ( abc->rtfs_bank == 1)?"b":" err");
     if (!strcmp(abc->command, "boot_normal")){
         return UPDATE_MODE_NORMAL;
     }

--- a/common/eswin/lib/boot_ab.c
+++ b/common/eswin/lib/boot_ab.c
@@ -120,7 +120,7 @@ int get_bootmessage_from_disk(struct blk_desc *dev_desc,
     abc_blocks = DIV_ROUND_UP(sizeof(struct bootloader_message),
                   part_info->blksz);
     if (abc_blocks > part_info->size) {
-        printf("UPDATE: misc partition too small. Need at least %lu blocks but have %lu blocks.\n",
+        printf("UPDATE: misc partition too small. Need at least %lu blocks but have " LBAFU " blocks.\n",
                 abc_blocks, part_info->size);
         return -EIO;
     }
@@ -150,7 +150,7 @@ int get_bootbank_from_disk(struct blk_desc *dev_desc,
     bank_blocks = DIV_ROUND_UP(sizeof(struct boot_bank),
             part_info->blksz);
     if (bank_blocks > part_info->size) {
-        printf("UPDATE: misc partition too small. Need at least %lu blocks, but have %lu blocks.\n",
+        printf("UPDATE: misc partition too small. Need at least %lu blocks, but have " LBAFU " blocks.\n",
                 bank_blocks, part_info->size);
         return -EIO;
     }

--- a/drivers/ata/dwc_ahsata_eswin.c
+++ b/drivers/ata/dwc_ahsata_eswin.c
@@ -387,8 +387,9 @@ static int ahci_fill_sg(struct ahci_uc_priv *uc_priv, u8 port,
 	}
 
 	for (i = 0; i < sg_count; i++) {
-		ahci_sg->addr =
-			cpu_to_le32((u32)buf + i * max_bytes);
+		u64 addr = (uintptr_t)buf + i * max_bytes;
+
+		ahci_sg->addr = cpu_to_le32(lower_32_bits(addr));
 		ahci_sg->addr_hi = 0;
 		ahci_sg->flags_size = cpu_to_le32(0x3fffff &
 					(buf_len < max_bytes

--- a/drivers/ata/dwc_ahsata_eswin.c
+++ b/drivers/ata/dwc_ahsata_eswin.c
@@ -962,7 +962,7 @@ static int eswin_sata_reset(struct udevice *dev)
     return 0;
 }
 
-static int eswin_sata_init_cfg()
+static int eswin_sata_init_cfg(void)
 {
 	unsigned long hsp_io_mem = HSP_CSR_BASE_ADDR;
 	eswin_ahci_write((void *)(hsp_io_mem + SATA_REF_CTRL1), 0x1);

--- a/drivers/clk/eswin/clk_eic770x.c
+++ b/drivers/clk/eswin/clk_eic770x.c
@@ -276,7 +276,6 @@ static ulong eic770x_clk_get_bootspi_rate(struct clk *clk)
 
 static ulong eic770x_clk_get_rate(struct clk *clk)
 {
-	struct eic770x_clk_priv *priv = dev_get_priv(clk->dev);
 	int id = clk->id;
 	ulong rate = -1;
 
@@ -339,7 +338,6 @@ static ulong eic770x_clk_get_rate(struct clk *clk)
 static ulong eic770x_clk_set_rate(struct clk *clk, ulong rate)
 {
 	ulong new_rate;
-	struct eic770x_clk_priv *priv = dev_get_priv(clk->dev);
 
 	switch (clk->id) {
 		case EIC7X_CLK_HSP_MSHC1_CORE_CLK:

--- a/drivers/mailbox/eswin-umbox-lpcpu.c
+++ b/drivers/mailbox/eswin-umbox-lpcpu.c
@@ -178,20 +178,14 @@ static int eswin_umbox_recv(struct mbox_chan *chan, void *data)
     struct eswin_umbox *umbox = dev_get_priv(chan->dev);
     struct eswin_umbox_session *umbox_session;
     unsigned int state0, i;
-    void *pOffset;
-    void *pOffset_tmp;
     u8 regData0[8];
-    u8 regData1[8];
     u32 msg[MBOX_MSG_LEN];
-    int len, ret, count;
-    REGISTER_DATA_T rData;
+    int count;
     umbox_session = umbox->umbox_session;
 
     u32 dwVal;
     unsigned int state;
     unsigned int ack_irq = 0;
-    RECV_MSG_EXT_T *pMsg;
-    IPC_RES_T IpcResData;
 
     debug("\r\nwin2030_umbox_recv: start...\n");
     while (1) {

--- a/drivers/mailbox/eswin-umbox-lpcpu.c
+++ b/drivers/mailbox/eswin-umbox-lpcpu.c
@@ -275,7 +275,7 @@ static int eswin_umbox_send(struct mbox_chan *chan, const void *data)
     }
 
     u8 * testaddr= (u8 *)data;
-    printf("testaddr = %x\n", (unsigned int)testaddr);
+    printf("testaddr = %p\n", testaddr);
     ret = Fill_RData(&rData, chan, testaddr);
     if (0 != ret) {
         printk("win2030_umbox_send: Fill_RData return %d, failed.\r\n", ret);

--- a/drivers/pci/pcie_dw_eswin.c
+++ b/drivers/pci/pcie_dw_eswin.c
@@ -77,7 +77,6 @@ struct eswin_pcie {
 /* sys crg base */
 #define SYSCRG_CSR    0x01828000
 
-#define PCI_EXP_DEVCTL_PAYLOAD  (0x00e0)  /* Max_Payload_Size */
 #define PCIE_CAP_MAX_PAYLOAD_SIZE(x)    ((x) << 5)
 #define PCIE_CAP_MAX_READ_REQ_SIZE(x)   ((x) << 12)
 

--- a/drivers/spi/es_spi.c
+++ b/drivers/spi/es_spi.c
@@ -938,13 +938,11 @@ static int es_spi_set_speed(struct udevice *bus, uint speed)
 {
 	struct es_spi_plat *plat = dev_get_plat(bus);
 	struct es_spi_priv *priv = dev_get_priv(bus);
-	u16 clk_div;
 
 	if (speed > plat->frequency)
 		speed = plat->frequency;
 
 	priv->freq = speed;
-	//dev_err(bus, "speed=%d clk_div=%d\n", priv->freq, clk_div);
 
 	return 0;
 }

--- a/drivers/spi/es_spi.c
+++ b/drivers/spi/es_spi.c
@@ -493,7 +493,7 @@ static void spi_read_write_cfg(struct es_spi_priv *priv, u32 byte, u32 addr)
 /**
  *  @brief write data from dest address to flash
  */
-static void spi_send_data(struct es_spi_priv *priv, u32 *dest, u32 size)
+static void spi_send_data(struct es_spi_priv *priv, u8 *dest, u32 size)
 {
     u32  offset          = 0;
     u8  *write_byte_buff = NULL;
@@ -506,7 +506,7 @@ static void spi_send_data(struct es_spi_priv *priv, u32 *dest, u32 size)
     }
 
     if (size != 0) {
-        write_byte_buff = (u8 *)dest;
+        write_byte_buff = dest;
         for (int i = 0; i < size; i++) {
             flash_end_data |= (*write_byte_buff) << (8 * i);
             write_byte_buff++;
@@ -589,7 +589,7 @@ void es_writer(struct es_spi_priv *priv)
 		}
 
 		spi_read_write_cfg(priv, write_size, offset);
-		spi_send_data(priv, (u32 *)wr_dest, write_size);
+		spi_send_data(priv, wr_dest, write_size);
 		spi_command_cfg(priv, cmd_code, cmd_type);
 		spi_wait_over(priv);
 		wr_dest += write_size;
@@ -729,7 +729,7 @@ void es_write_flash_status_register(struct es_spi_priv *priv, uint8_t register_d
 
 	//Flash status register-2 is 1byte
 	spi_read_write_cfg(priv, 1, 0);
-	spi_send_data(priv, (u32 *)&register_data, 1);
+	spi_send_data(priv, &register_data, 1);
 
 	command = es_read(priv, ES_SPI_CSR_06);
 	command &= ~((0xFF << 6) | (0x1 << 5) | (0xF << 1) | 0x1);


### PR DESCRIPTION
* spi: remove unused variable in es_spi_set_speed()
* spi: correct signature of spi_send_data()
* pci: do not redefine PCI_EXP_DEVCTL_PAYLOAD
* mailbox: use %p to print pointer in eswin_umbox_send()
* mailbox: remove unused variables in eswin_umbox_recv()
* ata: correct eswin_sata_init_cfg() definition
* clk: remove unused variable in eic770x_clk_get_rate()
* eswin: use correct printf code for lbaint_t
* eswin: correct printing in get_misc_command()
* ata: correct address conversion in ahci_fill_sg()
