### PR TITLE
eswin: use vidconsole as primary output

### DIFF
--- a/include/configs/eswin_eic7700_evb.h
+++ b/include/configs/eswin_eic7700_evb.h
@@ -43,8 +43,8 @@
     "emmc_dev=0\0" \
     "boot_conf_file=/extlinux/extlinux.conf\0" \
     "stdin=serial,usbkbd\0" \
-    "stderr=serial,vidconsole\0" \
-    "stdout=serial,vidconsole\0"
+    "stderr=vidconsole,serial\0" \
+    "stdout=vidconsole,serial\0"
     //BOOTENV
 #undef CONFIG_BOOTCOMMAND
 

--- a/include/configs/hifive_premier_p550.h
+++ b/include/configs/hifive_premier_p550.h
@@ -35,8 +35,8 @@
     "pxefile_addr_r=0x88200000\0" \
     "ramdisk_addr_r=0x88300000\0" \
     "stdin=serial,usbkbd\0" \
-    "stderr=serial,vidconsole\0" \
-    "stdout=serial,vidconsole\0" \
+    "stderr=vidconsole,serial\0" \
+    "stdout=vidconsole,serial\0" \
     "kernel_comp_addr_r=0xa0000000\0" \
     "kernel_comp_size=0x4000000\0" \
     "emmc_dev=0\0" \


### PR DESCRIPTION
The first device mentioned in variable stdout is used to identify the screen-size for the EFI sub-system.