### PR TITLE
cmd/es_bootloader: esburn_init_load_addr() needs integer argument

### DIFF
--- a/cmd/eswin/es_bootloader.c
+++ b/cmd/eswin/es_bootloader.c
@@ -1177,7 +1177,7 @@ static int do_mmc_write(int argc, char *const argv[])
 	if (!mmc)
 		return CMD_RET_FAILURE;
 
-	if(esburn_init_load_addr(addr, cnt)) {
+	if (esburn_init_load_addr((uintptr_t)addr, cnt)) {
 		puts("\nes_burn error: ");
 		puts("trying to overwrite reserved memory...\n");
 		return -ENXIO;


### PR DESCRIPTION
Fix a build failure:

    cmd/eswin/es_bootloader.c: In function ‘do_mmc_write’:
    cmd/eswin/es_bootloader.c:1180:34: error: passing argument 1 of
    ‘esburn_init_load_addr’ makes integer from pointer without a cast
    [-Wint-conversion]
     1180 |         if(esburn_init_load_addr(addr, cnt)) {
          |                                  ^~~~
          |                                  |
          |                                  void *
    cmd/eswin/es_bootloader.c:90:43: note: expected ‘uint64_t’
    {aka ‘long long unsigned int’} but argument is of type ‘void *’
       90 | static int esburn_init_load_addr(uint64_t addr, uint64_t size)
          |                                  ~~~~~~~~~^~~~