### PR TITLE
Revert spi: correct signature of spi_send_data()

### DIFF
--- a/drivers/spi/es_spi.c
+++ b/drivers/spi/es_spi.c
@@ -494,7 +494,7 @@ static void spi_read_write_cfg(struct es_spi_priv *priv, u32 byte, u32 addr)
 /**
  *  @brief write data from dest address to flash
  */
-static void spi_send_data(struct es_spi_priv *priv, u8 *dest, u32 size)
+static void spi_send_data(struct es_spi_priv *priv, u32 *dest, u32 size)
 {
     u32  offset          = 0;
     u8  *write_byte_buff = NULL;
@@ -507,7 +507,7 @@ static void spi_send_data(struct es_spi_priv *priv, u8 *dest, u32 size)
     }
 
     if (size != 0) {
-        write_byte_buff = dest;
+        write_byte_buff = (u8 *)dest;
         for (int i = 0; i < size; i++) {
             flash_end_data |= (*write_byte_buff) << (8 * i);
             write_byte_buff++;
@@ -590,7 +590,7 @@ void es_writer(struct es_spi_priv *priv)
 		}
 
 		spi_read_write_cfg(priv, write_size, offset);
-		spi_send_data(priv, wr_dest, write_size);
+		spi_send_data(priv, (u32 *)wr_dest, write_size);
 		spi_command_cfg(priv, cmd_code, cmd_type);
 		spi_wait_over(priv);
 		wr_dest += write_size;
@@ -730,7 +730,7 @@ void es_write_flash_status_register(struct es_spi_priv *priv, uint8_t register_d
 
 	//Flash status register-2 is 1byte
 	spi_read_write_cfg(priv, 1, 0);
-	spi_send_data(priv, &register_data, 1);
+	spi_send_data(priv, (u32 *)&register_data, 1);
 
 	command = es_read(priv, ES_SPI_CSR_06);
 	command &= ~((0xFF << 6) | (0x1 << 5) | (0xF << 1) | 0x1);


### PR DESCRIPTION
Commit affa8263f7b4 ("spi: correct signature of spi_send_data()") lead to incorrect data written to by the esburn command.

Fixes: affa8263f7b4 ("spi: correct signature of spi_send_data()")
