### PR TITLE
Remove .github/pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,0 @@
-Please do not submit a Pull Request via github.  Our project makes use of
-mailing lists for patch submission and review.  For more details please
-see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html
-
-The only exception to this is in order to trigger a CI loop on Azure prior
-to posting of patches.


### PR DESCRIPTION
Pull-request on Github are supported by Eswin.
Remove the message to the contrary.