### PR TITLE
Avoid build-failure due to an implicit function declaration

### DIFF
--- a/board/eswin/hifive_premier_p550/hifive_premier_p550.c
+++ b/board/eswin/hifive_premier_p550/hifive_premier_p550.c
@@ -222,7 +222,7 @@ int set_voltage_default(void)
 	ofnode node;
 	struct udevice *pinctrl;
 	struct gpio_desc desc;
-	int ret = 0;
+
 	node = ofnode_path("/config");
 	if (!ofnode_valid(node)) {
 		pr_err("Can't find /config node!\n");

--- a/board/eswin/hifive_premier_p550/hifive_premier_p550.c
+++ b/board/eswin/hifive_premier_p550/hifive_premier_p550.c
@@ -35,8 +35,9 @@
 #include <spi.h>
 #include <spi_flash.h>
 #include <init.h>
-#include <dm/device-internal.h>
 #include <asm/gpio.h>
+#include <dm/device-internal.h>
+#include <dm/pinctrl.h>
 #ifdef CONFIG_ESWIN_UMBOX
 #include <eswin/eswin-umbox-srvc.h>
 #endif


### PR DESCRIPTION
* Avoid a build failure
    ```
  board/eswin/hifive_premier_p550/hifive_premier_p550.c:234:12: error:
  implicit declaration of function ‘pinctrl_select_state’
  [-Wimplicit-function-declaration]
    234 |         if(pinctrl_select_state(pinctrl, "default")) {
        |            ^~~~~~~~~~~~~~~~~~~~
  ```

* Remove unused variable ret in set_voltage_default()